### PR TITLE
Move the WaitForYellowStatus into a goroutine so health checks can start passing sooner

### DIFF
--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -15,31 +15,36 @@ type Elasticer struct {
 	es      *elastic.Client
 	baseURL string
 	index   string
+	ready   bool
 }
 
 var httpClient = http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
-// NewElasticer returns a pointer to an Elasticer instance that has already tested its connection
-// by making a WaitForStatus call to the configured Elasticsearch cluster
+// NewElasticer returns a pointer to an Elasticer instance
 func NewElasticer(elasticsearchBase string, user string, password string, elasticsearchIndex string) (*Elasticer, error) {
 	c, err := elastic.NewClient(
 		elastic.SetSniff(false),
 		elastic.SetURL(elasticsearchBase),
 		elastic.SetBasicAuth(user, password),
-		elastic.SetHealthcheckTimeoutStartup(30*time.Second),
+		elastic.SetHealthcheckTimeoutStartup(60*time.Second),
 		elastic.SetHttpClient(&httpClient))
 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create elastic client")
 	}
 
-	wait := "90s"
-	err = c.WaitForYellowStatus(wait)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Cluster did not report yellow or better status within %s", wait)
-	}
-
 	return &Elasticer{es: c, baseURL: elasticsearchBase, index: elasticsearchIndex}, nil
+}
+
+// Check checks that the connection is good by making a WaitForStatus call to
+// the configured Elasticsearch cluster
+func (e *Elasticer) Check() error {
+	wait := "90s"
+	err := e.es.WaitForYellowStatus(wait)
+	if err != nil {
+		return errors.Wrapf(err, "Cluster did not report yellow or better status within %s", wait)
+	}
+	return nil
 }
 
 // Search returns an *elastic.SearchService set to the right index, for further use

--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -33,7 +33,7 @@ func NewElasticer(elasticsearchBase string, user string, password string, elasti
 		return nil, errors.Wrap(err, "Failed to create elastic client")
 	}
 
-	return &Elasticer{es: c, baseURL: elasticsearchBase, index: elasticsearchIndex}, nil
+	return &Elasticer{es: c, baseURL: elasticsearchBase, index: elasticsearchIndex, ready: false}, nil
 }
 
 // Check checks that the connection is good by making a WaitForStatus call to
@@ -44,6 +44,7 @@ func (e *Elasticer) Check() error {
 	if err != nil {
 		return errors.Wrapf(err, "Cluster did not report yellow or better status within %s", wait)
 	}
+	e.ready = true
 	return nil
 }
 

--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -12,53 +12,67 @@ import (
 
 // Elasticer is a type used to interact with Elasticsearch
 type Elasticer struct {
-	es      *elastic.Client
-	baseURL string
-	index   string
-	ready   bool
+	es       *elastic.Client
+	baseURL  string
+	index    string
+	user     string
+	password string
+
+	Ready bool
 }
 
 var httpClient = http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
-// NewElasticer returns a pointer to an Elasticer instance
-func NewElasticer(elasticsearchBase string, user string, password string, elasticsearchIndex string) (*Elasticer, error) {
+// NewElasticer returns a pointer to an Elasticer instance that needs to be set up with Setup()
+func NewElasticer(elasticsearchBase string, user string, password string, elasticsearchIndex string) *Elasticer {
+	return &Elasticer{es: nil, baseURL: elasticsearchBase, index: elasticsearchIndex, user: user, password: password, Ready: false}
+}
+
+// Setup sets up the elasticsearch client and checks that the connection is
+// good by making a WaitForStatus call to the configured Elasticsearch cluster
+func (e *Elasticer) Setup() error {
 	c, err := elastic.NewClient(
 		elastic.SetSniff(false),
-		elastic.SetURL(elasticsearchBase),
-		elastic.SetBasicAuth(user, password),
+		elastic.SetURL(e.baseURL),
+		elastic.SetBasicAuth(e.user, e.password),
 		elastic.SetHealthcheckTimeoutStartup(60*time.Second),
 		elastic.SetHttpClient(&httpClient))
 
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create elastic client")
+		return errors.Wrap(err, "Failed to create elastic client")
 	}
+	e.es = c
 
-	return &Elasticer{es: c, baseURL: elasticsearchBase, index: elasticsearchIndex, ready: false}, nil
-}
-
-// Check checks that the connection is good by making a WaitForStatus call to
-// the configured Elasticsearch cluster
-func (e *Elasticer) Check() error {
 	wait := "90s"
-	err := e.es.WaitForYellowStatus(wait)
+	err = e.es.WaitForYellowStatus(wait)
 	if err != nil {
 		return errors.Wrapf(err, "Cluster did not report yellow or better status within %s", wait)
 	}
-	e.ready = true
+	e.Ready = true
 	return nil
 }
 
 // Search returns an *elastic.SearchService set to the right index, for further use
 func (e *Elasticer) Search() *elastic.SearchService {
-	return e.es.Search().Index(e.index)
+	if e.Ready {
+		return e.es.Search().Index(e.index)
+	} else {
+		return nil
+	}
 }
 
 // Scroll returns an *elastic.ScrollService set to the right index, for further use
 func (e *Elasticer) Scroll() *elastic.ScrollService {
-	return e.es.Scroll().Index(e.index)
+	if e.Ready {
+		return e.es.Scroll().Index(e.index)
+	} else {
+		return nil
+	}
 }
 
 // Close calls out to the Stop method of the underlying elastic.Client
 func (e *Elasticer) Close() {
-	e.es.Stop()
+	if e.es != nil {
+		e.es.Stop()
+	}
 }

--- a/k8s/search.yml
+++ b/k8s/search.yml
@@ -84,7 +84,7 @@ spec:
           periodSeconds: 5
         readinessProbe:
           httpGet:
-            path: /debug/vars
+            path: /ready
             port: 60000
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/main.go
+++ b/main.go
@@ -69,6 +69,14 @@ func main() {
 	}
 	defer e.Close()
 
+	// Check in a goroutine so the service can start up & respond to health checks sooner
+	go func(e *elasticsearch.Elasticer) {
+		err := e.Check()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}(e)
+
 	r := newRouter(e)
 	listenPortSpec := ":" + "60000"
 	log.Infof("Listening on %s", listenPortSpec)


### PR DESCRIPTION
The integrated initial health check has also been increased to a 60 second timeout.

This _should_ mean that the service will still fail to start if ES is completely unreachable, which would happen if it's down or if the service is misconfigured, but won't crash immediately if it's merely being slow or is going through recovery. In that case, the goroutine should kill the service after a little while, and then it'll restart itself. Not sure if this is the right tradeoff, but it's at least better.